### PR TITLE
modifying solution in lab03 Dockerfile

### DIFF
--- a/lab03/solution/Dockerfile
+++ b/lab03/solution/Dockerfile
@@ -1,7 +1,10 @@
-FROM node:12
-RUN apt-get update -y \
-    && apt-get install -y libreoffice \
-    && apt-get clean
+FROM node:12-buster
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libreoffice \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /usr/src/app
 COPY package.json package*.json ./
 RUN npm install --only=production


### PR DESCRIPTION
```
Err:12 http://deb.debian.org/debian stretch-updates/main amd64 Packages
  404  Not Found
Reading package lists...
W: The repository 'http://security.debian.org/debian-security stretch/updates Release' does not have a Release file.
W: The repository 'http://deb.debian.org/debian stretch Release' does not have a Release file.
W: The repository 'http://deb.debian.org/debian stretch-updates Release' does not have a Release file.
E: Failed to fetch http://security.debian.org/debian-security/dists/stretch/updates/main/binary-amd64/Packages  404  Not Found
E: Failed to fetch http://deb.debian.org/debian/dists/stretch/main/binary-amd64/Packages  404  Not Found
E: Failed to fetch http://deb.debian.org/debian/dists/stretch-updates/main/binary-amd64/Packages  404  Not Found
E: Some index files failed to download. They have been ignored, or old ones used instead.
The command '/bin/sh -c apt-get update -y     && apt-get install -y libreoffice     && apt-get clean' returned a non-zero code: 100
ERROR
```

with the previous docker file getting the above error as the package repositories for Debian Stretch are no longer available. Debian Stretch reached its end of life in July 2020, and its repositories have been moved to archive servers.